### PR TITLE
fix action-name #26

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ export default {
 
 Ex. Unsubscribe collection
 
-#### part1. Add `firestoreUnsubscribeActions` in actions
+#### part1. Add `firestoreUnsubscribeAction` in actions
 
 - method: `firestoreUnsubscribeAction` or `firestoreUnsubscribeActions`
   - `firestoreUnsubscribeActions` is deprecated. It will be removed at `^1.0.0~`

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ export default {
 ```
 
 #### part2. Add below actions to namespaced Store
-
-- method: `firestoreSubscribeActions`
+- method: `firestoreSubscribeAction` or `firestoreSubscribeActions`
+  - `firestoreSubscribeActions` is deprecated. It will be removed at `^1.0.0~`
 - argments:
 
   - ref: firebase.firestore.DocumentReference | firebase.firestore.CollectionReference | firebase.firestore.Query
@@ -104,7 +104,7 @@ export default {
     ...firestoreMutations({ statePropName: 'comments', type: 'collection' })
   },
   actions: {
-    ...firestoreSubscribeActions({ ref: firestore.collection('/comments') })
+    ...firestoreSubscribeAction({ ref: firestore.collection('/comments') })
   }
 .....
 }
@@ -194,7 +194,8 @@ Ex. Unsubscribe collection
 
 #### part1. Add `firestoreUnsubscribeActions` in actions
 
-- method: `firestoreUnsubscribeActions`
+- method: `firestoreUnsubscribeAction` or `firestoreUnsubscribeActions`
+  - `firestoreUnsubscribeActions` is deprecated. It will be removed at `^1.0.0~`
 - argments:
 
   - type: 'document' | 'collection'
@@ -211,8 +212,8 @@ export default {
     ...firestoreMutations({ statePropName: 'comments', type: 'collection' })
   },
   actions: {
-    ...firestoreSubscribeActions({ ref: firestore.collection('/comments') }),
-    ...firestoreUnsubscribeActions({ type: 'collection' })
+    ...firestoreSubscribeAction({ ref: firestore.collection('/comments') }),
+    ...firestoreUnsubscribeAction({ type: 'collection' })
   }
 .....
 }

--- a/src/store/actions/index.ts
+++ b/src/store/actions/index.ts
@@ -1,2 +1,2 @@
-export { firestoreSubscribeActions } from './subscribe-action'
-export { firestoreUnsubscribeActions } from './unsibscribe-action'
+export { firestoreSubscribeActions, firestoreSubscribeAction } from './subscribe-action'
+export { firestoreUnsubscribeActions, firestoreUnsubscribeAction } from './unsibscribe-action'

--- a/src/store/actions/subscribe-action.ts
+++ b/src/store/actions/subscribe-action.ts
@@ -11,6 +11,7 @@ interface Criteria<T = any> {
 }
 
 /**
+ * @warn It is deprecated. It will be removed at `^1.0.0~`
  * @description subscribe firestore data to state property
  * @param actionName custom action name. can undefined
  * @param ref firebase.firestore.DocumentReference | firebase.firestore.CollectionReference | firebase.firestore.Query
@@ -23,6 +24,37 @@ interface Criteria<T = any> {
  *   - onCompleted `deprecated`
  */
 export const firestoreSubscribeActions = <T = any>({
+  ref,
+  actionName,
+  options
+}: Criteria<T>): ActionTree<any, any> => {
+  const defaultActionName = isDocumentRef(ref)
+    ? actionTypes.document.SUBSCRIBE
+    : actionTypes.collection.SUBSCRIBE
+
+  const action = actionName ? actionName : defaultActionName
+
+  const tree: ActionTree<any, any> = {
+    [action]({ state, commit }) {
+      subscribeFirestore({ state, commit, ref, options })
+    }
+  }
+  return tree
+}
+
+/**
+ * @description subscribe firestore data to state property
+ * @param actionName custom action name. can undefined
+ * @param ref firebase.firestore.DocumentReference | firebase.firestore.CollectionReference | firebase.firestore.Query
+ * @param options optional methods. can undefined
+ *   - mapper
+ *   - errorHandler
+ *   - completionHandler
+ *   - notFoundHandler
+ *   - afterMutationCalled
+ *   - onCompleted `deprecated`
+ */
+export const firestoreSubscribeAction = <T = any>({
   ref,
   actionName,
   options

--- a/src/store/actions/unsibscribe-action.ts
+++ b/src/store/actions/unsibscribe-action.ts
@@ -9,11 +9,37 @@ interface Criteria {
 }
 
 /**
+ * @warn It is deprecated. It will be removed at `^1.0.0~`
  * @description unsubscribe firestore data
  * @param type 'document' | 'collection'
  * @param actionName can undefined. But if you define actionName in `firestoreSubscribeActions`, set same name.
  */
 export const firestoreUnsubscribeActions = ({
+  type,
+  actionName
+}: Criteria): ActionTree<any, any> => {
+  const defaultActionName =
+    type === 'document'
+      ? actionTypes.document.UNSUBSCRIBE
+      : actionTypes.collection.UNSUBSCRIBE
+
+  const action = actionName ? actionName : defaultActionName
+
+  const tree: ActionTree<any, any> = {
+    [action]({ state }) {
+      unsubscribeFirestore({ state, type })
+    }
+  }
+
+  return tree
+}
+
+/**
+ * @description unsubscribe firestore data
+ * @param type 'document' | 'collection'
+ * @param actionName can undefined. But if you define actionName in `firestoreSubscribeAction`, set same name.
+ */
+export const firestoreUnsubscribeAction = ({
   type,
   actionName
 }: Criteria): ActionTree<any, any> => {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,6 +1,8 @@
 export { firestoreMutations } from './mutations'
 export {
+  firestoreSubscribeAction,
   firestoreSubscribeActions,
+  firestoreUnsubscribeAction,
   firestoreUnsubscribeActions
 } from './actions'
 

--- a/tests/__tests__/store/actions/subscribe-action.test.ts
+++ b/tests/__tests__/store/actions/subscribe-action.test.ts
@@ -3,6 +3,7 @@ import * as Vuex from 'vuex'
 import { Store, Module } from 'vuex'
 import {
   firestoreSubscribeActions,
+  firestoreSubscribeAction,
   actionTypes,
   firestoreMutations
 } from '../../../../src'
@@ -97,6 +98,97 @@ describe('subscribe-action', () => {
     await store.dispatch(`user/${actionTypes.DOCUMENT_SUBSCRIBE}`)
 
     expect(subscribeFirestore).toHaveBeenCalledTimes(3)
+
+    done()
+  })
+})
+
+
+describe('subscribe-action', () => {
+  let store: Store<any>
+  beforeEach(() => {
+    store = new Store({
+      modules: {},
+      state: {},
+      getters: {},
+      mutations: {},
+      actions: {}
+    })
+  })
+
+  it('subscribe collection , default action name and', async (done) => {
+    const commentModule: Module<any, any> = {
+      namespaced: true,
+      state: {
+        comments: null
+      },
+      getters: {},
+      mutations: {
+        ...firestoreMutations({ statePropName: 'comments', type: 'collection' })
+      },
+      actions: {
+        ...firestoreSubscribeAction({ ref: firestore.collection('/comments') })
+      }
+    }
+
+    store.registerModule('comment', commentModule)
+
+    await store.dispatch(`comment/${actionTypes.COLLECTION_SUBSCRIBE}`)
+
+    expect(subscribeFirestore).toHaveBeenCalledTimes(4)
+
+    done()
+  })
+
+  it('subscribe collection , custom action name', async (done) => {
+    const commentModule: Module<any, any> = {
+      namespaced: true,
+      state: {
+        comments: null
+      },
+      getters: {},
+      mutations: {
+        ...firestoreMutations({ statePropName: 'comments', type: 'collection' })
+      },
+      actions: {
+        ...firestoreSubscribeAction({
+          ref: firestore.collection('/comments'),
+          actionName: 'test'
+        })
+      }
+    }
+
+    store.registerModule('comment', commentModule)
+
+    await store.dispatch(`comment/test`)
+
+    expect(subscribeFirestore).toHaveBeenCalledTimes(5)
+
+    done()
+  })
+
+  it('subscribe document , custom action name', async (done) => {
+    const userModule: Module<any, any> = {
+      namespaced: true,
+      state: {
+        user: null
+      },
+      getters: {},
+      mutations: {
+        ...firestoreMutations({ statePropName: 'user', type: 'document' })
+      },
+      actions: {
+        ...firestoreSubscribeAction({
+          ref: firestore.collection('/users').doc('userId')
+        })
+      }
+    }
+
+    store.registerModule('user', userModule)
+
+    await store.dispatch(`user/${actionTypes.DOCUMENT_SUBSCRIBE}`)
+
+    expect(subscribeFirestore).toHaveBeenCalledTimes(6)
 
     done()
   })

--- a/tests/__tests__/store/actions/unsubscribe-action.test.ts
+++ b/tests/__tests__/store/actions/unsubscribe-action.test.ts
@@ -4,14 +4,15 @@ import { Store, Module } from 'vuex'
 import {
   actionTypes,
   firestoreMutations,
-  firestoreUnsubscribeActions
+  firestoreUnsubscribeActions,
+  firestoreUnsubscribeAction
 } from '../../../../src'
 import { unsubscribeFirestore } from '../../../../src/store/helpers/unsubscribe'
 jest.mock('../../../../src/store/helpers/unsubscribe')
 const localVue = createLocalVue()
 localVue.use(Vuex)
 
-describe('subscribe-action', () => {
+describe('unsubscribe-action', () => {
   let store: Store<any>
   beforeEach(() => {
     store = new Store({
@@ -23,7 +24,7 @@ describe('subscribe-action', () => {
     })
   })
 
-  it('subscribe collection , default action name and', async (done) => {
+  it('unsubscribe collection , default action name and', async (done) => {
     const commentModule: Module<any, any> = {
       namespaced: true,
       state: {
@@ -49,7 +50,7 @@ describe('subscribe-action', () => {
     done()
   })
 
-  it('subscribe collection , custom action name', async (done) => {
+  it('unsubscribe collection , custom action name', async (done) => {
     const commentModule: Module<any, any> = {
       namespaced: true,
       state: {
@@ -76,7 +77,7 @@ describe('subscribe-action', () => {
     done()
   })
 
-  it('subscribe document , custom action name', async (done) => {
+  it('unsubscribe document , custom action name', async (done) => {
     const userModule: Module<any, any> = {
       namespaced: true,
       state: {
@@ -98,6 +99,98 @@ describe('subscribe-action', () => {
     await store.dispatch(`user/${actionTypes.DOCUMENT_UNSUBSCRIBE}`)
 
     expect(unsubscribeFirestore).toHaveBeenCalledTimes(3)
+
+    done()
+  })
+})
+
+describe('unsubscribe-action', () => {
+  let store: Store<any>
+  beforeEach(() => {
+    store = new Store({
+      modules: {},
+      state: {},
+      getters: {},
+      mutations: {},
+      actions: {}
+    })
+  })
+
+  it('unsubscribe collection , default action name and', async (done) => {
+    const commentModule: Module<any, any> = {
+      namespaced: true,
+      state: {
+        comments: null
+      },
+      getters: {},
+      mutations: {
+        ...firestoreMutations({ statePropName: 'comments', type: 'collection' })
+      },
+      actions: {
+        ...firestoreUnsubscribeAction({
+          type: 'collection'
+        })
+      }
+    }
+
+    store.registerModule('comment', commentModule)
+
+    await store.dispatch(`comment/${actionTypes.COLLECTION_UNSUBSCRIBE}`)
+
+    expect(unsubscribeFirestore).toHaveBeenCalledTimes(4)
+
+    done()
+  })
+
+  it('unsubscribe collection , custom action name', async (done) => {
+    const commentModule: Module<any, any> = {
+      namespaced: true,
+      state: {
+        comments: null
+      },
+      getters: {},
+      mutations: {
+        ...firestoreMutations({ statePropName: 'comments', type: 'collection' })
+      },
+      actions: {
+        ...firestoreUnsubscribeAction({
+          type: 'collection',
+          actionName: 'test'
+        })
+      }
+    }
+
+    store.registerModule('comment', commentModule)
+
+    await store.dispatch(`comment/test`)
+
+    expect(unsubscribeFirestore).toHaveBeenCalledTimes(5)
+
+    done()
+  })
+
+  it('unsubscribe document , custom action name', async (done) => {
+    const userModule: Module<any, any> = {
+      namespaced: true,
+      state: {
+        user: null
+      },
+      getters: {},
+      mutations: {
+        ...firestoreMutations({ statePropName: 'user', type: 'document' })
+      },
+      actions: {
+        ...firestoreUnsubscribeAction({
+          type: 'document'
+        })
+      }
+    }
+
+    store.registerModule('user', userModule)
+
+    await store.dispatch(`user/${actionTypes.DOCUMENT_UNSUBSCRIBE}`)
+
+    expect(unsubscribeFirestore).toHaveBeenCalledTimes(6)
 
     done()
   })


### PR DESCRIPTION
- #26 
- `firestoreSubscribeActions` and `firestoreUnsubscribeAction` is deprecated. It will be removed at ^1.0.0~

- You use `firestoreSubscribeAction` and `firestoreUnsubscribeAction`, please