### PR TITLE
fix:[FirestoreStreamSubscriber] No duplication occurs if subscribe is called when subscribed

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,13 +6,13 @@ module.exports = {
     'plugin:@typescript-eslint/eslint-recommended',
 
     'plugin:prettier/recommended',
-    'prettier/@typescript-eslint'
+    'prettier/@typescript-eslint',
   ],
   plugins: ['@typescript-eslint'],
   parser: '@typescript-eslint/parser',
   env: { browser: true, node: true, es6: true },
   parserOptions: {
-    parser: '@typescript-eslint/parser'
+    parser: '@typescript-eslint/parser',
   },
   rules: {
     'no-unused-vars': 'off',
@@ -22,6 +22,7 @@ module.exports = {
     '@typescript-eslint/no-empty-interface': 'off',
     '@typescript-eslint/no-non-null-assertion': 'off',
     '@typescript-eslint/ban-ts-ignore': 'off',
-    '@typescript-eslint/ban-ts-comment': 'off'
-  }
+    '@typescript-eslint/ban-ts-comment': 'off',
+    '@typescript-eslint/explicit-module-boundary-types': 'off',
+  },
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,10 +2,11 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   testMatch: ['**/__tests__/**/*.ts?(x)', '**/?(*.)+(test).ts?(x)'],
+  collectCoverageFrom: ['**/*.ts', '!**/tests/**'],
   transformIgnorePatterns: ['node_modules'],
   globals: {
     'ts-jest': {
-      babelConfig: true
-    }
-  }
+      babelConfig: true,
+    },
+  },
 }

--- a/lib/services/firestore-stream-subscriber.service.d.ts
+++ b/lib/services/firestore-stream-subscriber.service.d.ts
@@ -5,6 +5,7 @@ import { Action } from 'stream-executor';
 export declare class FirestoreStreamSubscriber {
     private _ref;
     private _actions;
+    private _statePropName?;
     /**
      * Make FirestoreStreamSubscriber instance
      * @param ref: firebase.firestore.DocumentReference | firebase.firestore.CollectionReference | firebase.firestore.Query

--- a/lib/services/firestore-stream-subscriber.service.js
+++ b/lib/services/firestore-stream-subscriber.service.js
@@ -88,6 +88,10 @@ class FirestoreStreamSubscriber {
      * @param options { errorHandler, notFoundHandler, completionHandler }
      */
     subscribe(state, commit, options = {}) {
+        if (this._statePropName &&
+            state[configurations_1.FIREX_UNSUBSCRIBES].has(this._statePropName)) {
+            return;
+        }
         if (!state[configurations_1.FIREX_UNSUBSCRIBES]) {
             state[configurations_1.FIREX_UNSUBSCRIBES] = new Map();
         }
@@ -116,6 +120,7 @@ class FirestoreStreamSubscriber {
             });
         const unsubscribes = state[configurations_1.FIREX_UNSUBSCRIBES];
         const statePropName = unsubscribes.get(firestoreRefType);
+        this._statePropName = statePropName;
         unsubscribes.set(statePropName, unsubscribe);
         unsubscribes.delete(firestoreRefType);
     }

--- a/src/services/firestore-stream-subscriber.service.ts
+++ b/src/services/firestore-stream-subscriber.service.ts
@@ -9,6 +9,7 @@ import { tap, Action, map as _map } from 'stream-executor'
 export class FirestoreStreamSubscriber {
   private _ref: FirestoreRef
   private _actions: Action<any, any>[] = []
+  private _statePropName?: string
 
   /**
    * Make FirestoreStreamSubscriber instance
@@ -113,6 +114,13 @@ export class FirestoreStreamSubscriber {
       'errorHandler' | 'notFoundHandler' | 'completionHandler'
     > = {}
   ) {
+    if (
+      this._statePropName &&
+      (state[FIREX_UNSUBSCRIBES] as Unsubscribes).has(this._statePropName)
+    ) {
+      return
+    }
+
     if (!state[FIREX_UNSUBSCRIBES]) {
       state[FIREX_UNSUBSCRIBES] = new Map<string, Unsubscribe>()
     }
@@ -148,6 +156,7 @@ export class FirestoreStreamSubscriber {
 
     const unsubscribes: Unsubscribes = state[FIREX_UNSUBSCRIBES]
     const statePropName = unsubscribes.get(firestoreRefType) as string
+    this._statePropName = statePropName
     unsubscribes.set(statePropName, unsubscribe)
     unsubscribes.delete(firestoreRefType)
   }

--- a/tests/__tests__/services/firestore-stream-subscriber.test.ts
+++ b/tests/__tests__/services/firestore-stream-subscriber.test.ts
@@ -94,4 +94,42 @@ describe('FirestoreStreamSubscriber', () => {
     const unsubscribes: Unsubscribes = (state as any)[FIREX_UNSUBSCRIBES]
     expect(unsubscribes.get('charactor')).not.toBeUndefined()
   })
+
+  it('subscribe: call at once, only', () => {
+    const mockIsDocumentRef = (isDocumentRef as unknown) as jest.Mock
+    mockIsDocumentRef.mockImplementation(() => true)
+    const unsubscribe = () => jest.fn()
+    const state = {
+      charactor: null,
+      [FIREX_UNSUBSCRIBES]: new Map(),
+    }
+    const ref = {
+      onSnapshot: (onNext: any) => {
+        onNext(mockDocumentSnapshot)
+        return unsubscribe
+      },
+    }
+
+    // @ts-ignore
+    const subscriber = FirestoreStreamSubscriber.from(ref)
+
+    subscriber
+      .pipe(
+        map((data) => ({ id: data.docId, name: data.name })),
+        bindTo('charactor')
+      )
+      .subscribe(state, jest.fn())
+
+    expect(subscriber['_statePropName']).toEqual('charactor')
+    const spyRef = spyOn(ref, 'onSnapshot')
+
+    subscriber
+      .pipe(
+        map((data) => ({ id: data.docId, name: data.name })),
+        bindTo('charactor')
+      )
+      .subscribe(state, jest.fn())
+
+    expect(spyRef).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
# Before
- Duplicate data subscribed from firestore
```ts
const subcsriber = FirestoreStreamSubscriber.from(ref)

subscriber
  .pipe(...)
  .subscribe(state, commit) // [{ id: 'charactor1', name: 'sans' }]
subscriber
  .pipe(...)
  .subscribe(state, commit) // [{ id: 'charactor1', name: 'sans' }, { id: 'charactor1', name: 'sans' }]
```

# After
- No duplication occurs
```ts
const subcsriber = FirestoreStreamSubscriber.from(ref)

subscriber
  .pipe(...)
  .subscribe(state, commit) // [{ id: 'charactor1', name: 'sans' }]
subscriber
  .pipe(...)
  .subscribe(state, commit) // [{ id: 'charactor1', name: 'sans' }]
```